### PR TITLE
Adds `blockAs` prop

### DIFF
--- a/src/Block/index.tsx
+++ b/src/Block/index.tsx
@@ -27,7 +27,7 @@ export const Block: PolymorphicComponent<BlockProps> = React.forwardRef(
     }: PolymorphicComponentPropWithRef<C, Omit<BlockProps, 'as'>>,
     ref: PolymorphicRef<C>
   ) => {
-    const Element = as || 'div';
+    const Element = as || theme.options.blockAs || 'div';
 
     const hasBackground = Boolean(backgroundImage) || Boolean(renderCustomBackground);
 

--- a/src/Blocks/index.tsx
+++ b/src/Blocks/index.tsx
@@ -3,10 +3,13 @@ import { ElementType } from 'react';
 import { Block } from '@src/Block';
 import { MerengueData } from '@src/types';
 
-export const Blocks: ElementType<Required<Pick<MerengueData, 'blocks'>>> = ({ blocks }) => (
+export const Blocks: ElementType<Required<Pick<MerengueData, 'blocks' | 'blockAs'>>> = ({
+  blocks,
+  blockAs = 'div'
+}) => (
   <>
     {blocks.map(({ renderContent, ...block }, blockKey) => (
-      <Block key={blockKey} {...block}>
+      <Block key={blockKey} {...block} as={blockAs}>
         {renderContent()}
       </Block>
     ))}

--- a/src/MerengueBox/index.tsx
+++ b/src/MerengueBox/index.tsx
@@ -16,13 +16,13 @@ export const MerengueBox: PolymorphicComponent<MerengueData> = React.forwardRef(
     { blocks, children, ...props }: PolymorphicComponentPropWithRef<C, MerengueData>,
     ref: PolymorphicRef<C>
   ) => {
-    const { blockPadding, gap, columns, maxWidth, ...blockSetAttributes } = props;
+    const { blockPadding, gap, columns, maxWidth, blockAs, ...blockSetAttributes } = props;
 
-    theme.options = { blockPadding, gap, columns, maxWidth };
+    theme.options = { blockPadding, gap, columns, maxWidth, blockAs };
 
     return (
       <BlockSet {...blockSetAttributes} ref={ref}>
-        {Boolean(blocks) && <Blocks blocks={blocks} />}
+        {Boolean(blocks) && <Blocks blocks={blocks} blockAs={blockAs} />}
         {children}
       </BlockSet>
     );

--- a/src/stories/MerengueBox.stories.tsx
+++ b/src/stories/MerengueBox.stories.tsx
@@ -5,17 +5,33 @@ import { Story } from '@ladle/react';
 import { Block } from '../Block';
 import { MerengueBox } from '../MerengueBox';
 import { MerengueData } from '../types';
+import { CustomBackground } from './utils/CustomBackground';
 import { data } from './utils/data';
 
 export const FromDataObject: Story<MerengueData> = props => <MerengueBox {...data} {...props} />;
 
 FromDataObject.args = {
-  extendContent: false,
-  extendBackground: true,
-  maxWidth: 960,
+  as: 'ol',
+  blockAs: 'li',
+  blockPadding: '',
   columns: 4,
-  as: 'div',
+  extendBackground: true,
+  extendContent: false,
+  gap: 1,
+  maxWidth: '960px',
+  renderCustomBackground: CustomBackground,
 };
+
+const BlockContent = () => (
+  <>
+    <img src="http://placeimg.com/640/480/city" style={{ maxWidth: '100%' }} />
+    <h3>Transform</h3>
+    <p>
+      Ut quia qui eius. Veritatis nam unde. Inventore enim velit aut. Quis animi voluptas tempore
+      sed quibusdam doloribus ullam. Ab architecto fuga quo.
+    </p>
+  </>
+);
 
 export const Nested: Story<MerengueData> = props => {
   const ref = useRef(null);
@@ -23,11 +39,9 @@ export const Nested: Story<MerengueData> = props => {
   return (
     <MerengueBox {...props} as="ol" ref={ref}>
       <Block as="li" ref={ref2} onClick={() => console.log({ ref, ref2 })}>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat optio nemo, animi eligendi
-        voluptatem voluptatum. Sit facere fugit laudantium adipisci itaque similique incidunt, quos
-        assumenda totam! Eaque magni culpa quisquam.
+        <BlockContent />
       </Block>
-      <Block size={2}>
+      <Block>
         Lorem ipsum dolor sit amet consectetur adipisicing elit. Repellat optio nemo, animi eligendi
         voluptatem voluptatum. Sit facere fugit laudantium adipisci itaque similique incidunt, quos
         assumenda totam! Eaque magni culpa quisquam.
@@ -59,6 +73,5 @@ export const Nested: Story<MerengueData> = props => {
 Nested.args = {
   extendContent: false,
   extendBackground: true,
-  maxWidth: 600,
   columns: 4,
 };

--- a/src/stories/utils/data.tsx
+++ b/src/stories/utils/data.tsx
@@ -1,27 +1,17 @@
 import React from 'react';
 
 import { MerengueData } from '../../types';
-import { CustomBackground } from './CustomBackground';
 
 const MyComponent = () => (
-  <div>
-    {' '}
+  <>
     1 Lorem velit aliquip enim velit adipisicing magna. Elit tempor occaecat quis amet nulla. Magna
     proident cillum sunt irure id anim aliquip quis aliquip minim occaecat. Ullamco dolore enim est
     dolore ad enim labore quis aliqua esse esse. Est est non cupidatat magna consectetur duis
     officia dolor do commodo est magna dolor ut. Pariatur commodo ex eu excepteur ea.
-  </div>
+  </>
 );
 
 export const data: MerengueData = {
-  blockPadding: '',
-  gap: 1,
-  columns: 2,
-  maxWidth: '960px',
-  as: 'article',
-  renderCustomBackground: CustomBackground,
-  extendBackground: false,
-  extendContent: false,
   blocks: [
     {
       as: 'figure',
@@ -33,14 +23,13 @@ export const data: MerengueData = {
     {
       size: 2,
       renderContent: () => (
-        <div>
-          {' '}
+        <>
           2 Lorem velit aliquip enim velit adipisicing magna. Elit tempor occaecat quis amet nulla.
           Magna proident cillum sunt irure id anim aliquip quis aliquip minim occaecat. Ullamco
           dolore enim est dolore ad enim labore quis aliqua esse esse. Est est non cupidatat magna
           consectetur duis officia dolor do commodo est magna dolor ut. Pariatur commodo ex eu
           excepteur ea.
-        </div>
+        </>
       ),
       renderCustomBackground: undefined,
       backgroundImage: undefined,
@@ -48,13 +37,13 @@ export const data: MerengueData = {
     {
       size: 1,
       renderContent: () => (
-        <div>
+        <>
           3 Lorem velit aliquip enim velit adipisicing magna. Elit tempor occaecat quis amet nulla.
           Magna proident cillum sunt irure id anim aliquip quis aliquip minim occaecat. Ullamco
           dolore enim est dolore ad enim labore quis aliqua esse esse. Est est non cupidatat magna
           consectetur duis officia dolor do commodo est magna dolor ut. Pariatur commodo ex eu
           excepteur ea.
-        </div>
+        </>
       ),
       renderCustomBackground: undefined,
       backgroundImage: undefined,
@@ -62,13 +51,13 @@ export const data: MerengueData = {
     {
       size: 1,
       renderContent: () => (
-        <div>
+        <>
           4 Lorem velit aliquip enim velit adipisicing magna. Elit tempor occaecat quis amet nulla.
           Magna proident cillum sunt irure id anim aliquip quis aliquip minim occaecat. Ullamco
           dolore enim est dolore ad enim labore quis aliqua esse esse. Est est non cupidatat magna
           consectetur duis officia dolor do commodo est magna dolor ut. Pariatur commodo ex eu
           excepteur ea.
-        </div>
+        </>
       ),
       renderCustomBackground: undefined,
       backgroundImage: undefined,
@@ -76,13 +65,13 @@ export const data: MerengueData = {
     {
       size: 1,
       renderContent: () => (
-        <div>
+        <>
           5 Lorem velit aliquip enim velit adipisicing magna. Elit tempor occaecat quis amet nulla.
           Magna proident cillum sunt irure id anim aliquip quis aliquip minim occaecat. Ullamco
           dolore enim est dolore ad enim labore quis aliqua esse esse. Est est non cupidatat magna
           consectetur duis officia dolor do commodo est magna dolor ut. Pariatur commodo ex eu
           excepteur ea.
-        </div>
+        </>
       ),
       renderCustomBackground: undefined,
       backgroundImage: undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export type GridOptions = {
   gap?: 0 | 1 | 2 | 3 | 4;
   columns?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
   maxWidth?: string;
+  blockAs?: keyof AllowedTags;
 };
 
 export type MerengueData = BackgroundProps &


### PR DESCRIPTION
Allows the to pass a tag name to MerengueBox and determine how blocks should render in the DOM.
